### PR TITLE
updates for the move to the "redding" org and some other cleanups

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2012-Present Kelly Redding and Rooted West
+Copyright (c) 2012-Present Kelly Redding and Collin Redding
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# rb: The Ruby Auto Activator
+# rb
 
 ```
-$ rb @1.9.3 && ruby -v                           # set process to '1.9.3' install
-$ echo 'ree' > ./.ruby-version && rb && ruby -v  # set process to current `.ruby-version` ('ree') install
-$ rb @system && ruby -v                          # set process to system install
+$ rb @1.9.3 && ruby -v                           # activate '1.9.3' install
+$ echo 'ree' > ./.ruby-version && rb && ruby -v  # activate current `.ruby-version` ('ree') install
+$ rb @system && ruby -v                          # activate system install
 $ rb help
 ```
+
+Activate installed Ruby versions.
 
 ## What It Does
 
@@ -27,10 +29,10 @@ Each installed version of ruby should live in `$HOME/.rubies/<version>`.  Instal
 
 ## Install
 
-Open a terminal and run this command ([view source](http://git.io/rb-install)):
+Open a terminal and run this command ([view source](http://git.io/rb--install)):
 
 ```
-$ curl -L http://git.io/rb-install | sh
+$ curl -L http://git.io/rb--install | sh
 ```
 
 Add rb init to your shell startup script.  This installs tab completions and enables modifying the env vars.
@@ -49,7 +51,7 @@ eval "$(rb init --auto)"
 
 ```
 $ rb help
-The Ruby Auto Activator (release <release>)
+rb (<release> release)
 
 usage: rb [@<version>]
        rb -f <version_file>
@@ -58,7 +60,7 @@ usage: rb [@<version>]
        rb --version
 
 More Info:
-  https://github.com/rootedwest/rb/blob/<release>/README.md
+  https://github.com/redding/rb/blob/<release>/README.md
 ```
 
 ### Using With `.ruby-version` Files
@@ -99,10 +101,10 @@ $ rb @system
 
 ## Uninstall
 
-Open a terminal and run this command ([view source](http://git.io/rb-uninstall)):
+Open a terminal and run this command ([view source](http://git.io/rb--uninstall)):
 
 ```
-$ curl -L http://git.io/rb-uninstall | sh
+$ curl -L http://git.io/rb--uninstall | sh
 ```
 
 ## Contributing

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ RB_RELEASE="beta2"
 
       rm -rf "$RB_HOME_DIR" && mkdir -p "$RB_HOME_DIR"
       pushd "$RB_HOME_DIR" > /dev/null &&
-        curl -L "https://github.com/rootedwest/rb/tarball/$RB_RELEASE" | tar xzf - */libexec/*
+        curl -L "https://github.com/redding/rb/tarball/$RB_RELEASE" | tar xzf - */libexec/*
         ln -sf */libexec
       popd > /dev/null
 

--- a/libexec/rb
+++ b/libexec/rb
@@ -100,7 +100,7 @@ rb () {
     shift 1; eval "$cmd_bin $@"
   else
     if [ "$1" = "-v" ] || [ "$1" = "--version" ]; then echo "$RB_RELEASE"
-    elif [ "$1" = "-h" ] || [ "$1" = "--help" ];  then eval "rb-help"
+    elif [ "$1" = "-h" ] || [ "$1" = "--help" ];  then eval "rb help"
     elif [ "$1" = "-f" ]; then _rb_reset $2
     elif [[ $1 =~ ^@ ]];  then _rb_reset $@
     elif [ -z $1 ];       then _rb_reset

--- a/libexec/rb-help
+++ b/libexec/rb-help
@@ -4,7 +4,7 @@ command="$1"
 if [ -z $command ]; then
 
   cat <<USAGE
-The Ruby Auto Activator (release $RB_RELEASE)
+rb ($RB_RELEASE release)
 
 usage: rb [@<version>]
        rb -f <version_file>
@@ -13,7 +13,7 @@ usage: rb [@<version>]
        rb --version
 
 More Info:
-  https://github.com/rootedwest/rb/blob/$RB_RELEASE/README.md
+  https://github.com/redding/rb/blob/$RB_RELEASE/README.md
 USAGE
   exit 0
 


### PR DESCRIPTION
This removes the auto activator tag and just uses the "rb" name.
I updated the README with new install/uninstall URLs and updated
usage/help messages.

This includes a minor fix to `rb -h` as well.

@jcredding this is me getting rb setup in our org and cleaning up the repo a bit.  Please review for me man.  Would you mind trying an install as well?
