### PR TITLE
include the release in the local install dir name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# rb Change Log
+# rb Changelog
 
 ## (next release)
 
+* include the release in the local install dir name (#22)
 * `-f` option to specify version files to use (#13)
 * reset the env when activating from the `rb` cli (#9)
 * remove all whitespace when reading version string from files (#16)

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,8 @@ RB_RELEASE="beta2"
       rm -rf "$RB_HOME_DIR" && mkdir -p "$RB_HOME_DIR"
       pushd "$RB_HOME_DIR" > /dev/null &&
         curl -L "https://github.com/redding/rb/tarball/$RB_RELEASE" | tar xzf - */libexec/*
-        ln -sf */libexec
+        mv *rb-* "rb-$RB_RELEASE"
+        ln -sf "rb-$RB_RELEASE/libexec"
       popd > /dev/null
 
 # install in the bin path


### PR DESCRIPTION
This updates the script to rename the downloaded source dir to
include the release so its obvious what release is installed when
looking at the installed source.
