### PR TITLE
status cmd to print current ruby version and source info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## beta3 / Unreleased
 
+* status cmd to print current ruby version and source info (#24)
 * include the release in the local install dir name (#22)
 * `-f` option to specify version files to use (#13)
 * reset the env when activating from the `rb` cli (#9)

--- a/libexec/rb
+++ b/libexec/rb
@@ -104,7 +104,7 @@ rb () {
     elif [ "$1" = "-f" ]; then _rb_reset $2
     elif [[ $1 =~ ^@ ]];  then _rb_reset $@
     elif [ -z $1 ];       then _rb_reset
-    else echo "rb: no such command \`$command_arg'" >&2
+    else echo "rb: no such command \`$cmd_arg'" >&2
     fi
   fi
 }

--- a/libexec/rb-help
+++ b/libexec/rb-help
@@ -9,6 +9,7 @@ rb ($RB_RELEASE release)
 usage: rb [@<version>]
        rb -f <version_file>
        rb help [<cmd>]
+       rb status
        rb init [--auto]
        rb --version
 
@@ -26,6 +27,15 @@ Print command usage info.
 
 usage: rb help
        rb help [cmd]
+USAGE
+    exit 0
+
+  elif [[ "$command" == "status" ]]; then
+
+    cat <<USAGE
+Print the current version and source info
+
+usage: rb status
 USAGE
     exit 0
 

--- a/libexec/rb-status
+++ b/libexec/rb-status
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+cat <<STATUS
+$RB_RUBY_VERSION ($RB_RUBY_SOURCE)
+STATUS
+
+exit 0


### PR DESCRIPTION
Does just that.  Added appropriate help handling as well.

Closes #1.
