### PR TITLE
change auto handling to use the `PROMPT_COMMAND` env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ $ rb help
 
 Activate installed Ruby versions.
 
-## What It Does
+## What It Does...
 
-**modifies env vars**: activates installs by modifying the `PATH`, `GEM_HOME` and `GEM_PATH` env vars.  To accomplish this, it...
+**modifies env vars**: activates versions by modifying the `PATH`, `GEM_HOME` and `GEM_PATH` env vars.  To accomplish this, it...
 
-**adds functions to your shell**: for the activation, for resetting, and for the CLI.  These are needed to modify shell env vars.
+**adds functions to your shell**: for activating, resetting, and the CLI.  These are needed to modify shell env vars.
 
-**.ruby-version files**: supports specifying installs with `.ruby-version` files.
+**.ruby-version files**: supports specifying versions with `.ruby-version` files.
 
-**auto mode**: (optional) modify your env as you `cd` into a directory containing a `.ruby-version` file.  This is accomplished by overriding `cd` and is **optional**.
+**auto mode**: (optional) update the version when you `cd` to a directory containing a `.ruby-version` file (does not hook `cd`).
 
 **tab completions**: version string parameters, commands, etc.
 
@@ -41,7 +41,7 @@ Add rb init to your shell startup script.  This installs tab completions and ena
 eval "$(rb init)"
 ```
 
-(optional) If you want automatic handling, add the `--auto` flag.  In additon to the normal init above, this overrides `cd` so your ruby version is auto updated as you change directories.  It is **optional**.
+(optional) If you want automatic handling, add the `--auto` flag.  In additon to the normal init above, `$PROMPT_COMMAND` is updated to activate any new ruby version as you change directories.  **Again, this is optional.**
 
 ```bash
 eval "$(rb init --auto)"

--- a/libexec/rb
+++ b/libexec/rb
@@ -117,6 +117,10 @@ _rb_activate () {
 
 }
 
+_rb_auto_activate () {
+  [[ "$PWD" != "$RB_PWD" ]] && export RB_PWD="$PWD" && _rb_activate
+}
+
 rb () {
   reset () { _rb_unset_env; _rb_activate $@; }
   cmd_arg="$1"

--- a/libexec/rb-init
+++ b/libexec/rb-init
@@ -33,9 +33,15 @@ if [ "$1" = "--auto" ]; then
   # (optional) auto mode (update ruby version as you change directories)
 
   cat <<AUTO_MODE
-function cd () {
-  builtin cd "\$@" && _rb_activate
-}
+PROMPT_COMMAND="${PROMPT_COMMAND%% }"
+if [[ -n "$PROMPT_COMMAND" ]]; then
+  if [[ ! "$PROMPT_COMMAND" == *_rb_auto_activate* ]]; then
+    PROMPT_COMMAND="${PROMPT_COMMAND%%;}"
+    PROMPT_COMMAND="$PROMPT_COMMAND; _rb_auto_activate"
+  fi
+else
+  PROMPT_COMMAND="_rb_auto_activate"
+fi
 AUTO_MODE
 
 fi


### PR DESCRIPTION
This avoids an anti-feature of hooking the `cd` method.

Closes #19.
