### PR TITLE
`exec` command - execute a command using a specific ruby version

### DIFF
--- a/libexec/rb-exec
+++ b/libexec/rb-exec
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+argv=()
+
+for arg in $@; do
+  shift
+  if [[ "$arg" == "--" ]]; then
+    break
+  else
+    argv+=($arg)
+  fi
+done
+
+if [[ $# -eq 0 ]]; then
+  echo "rb: exec needs a command to run" >&2
+  exit 1
+fi
+
+exec $SHELL -l -i -c "_rb_activate $argv && $*"

--- a/libexec/rb-help
+++ b/libexec/rb-help
@@ -7,8 +7,9 @@ if [ -z $command ]; then
 '$RB_RELEASE' release
 
 usage: rb [@<version>]
-       rb -f <version_file>
-       rb help [<cmd>]
+       rb -f FILE
+       rb exec [@<version>] [-f FILE] -- COMMAND
+       rb help CMD
        rb status
        rb list
        rb init [--auto]
@@ -21,7 +22,18 @@ USAGE
 
 else
 
-  if [[ "$command" == "help" ]]; then
+  if [[ "$command" == "exec" ]]; then
+
+    cat <<USAGE
+Execute a command using a specific ruby version
+
+usage: rb exec -- COMMAND
+       rb exec @<version> -- COMMAND
+       rb exec -f FILE -- COMMAND
+USAGE
+    exit 0
+
+  elif [[ "$command" == "help" ]]; then
 
     cat <<USAGE
 Print command usage info.

--- a/libexec/rb-init
+++ b/libexec/rb-init
@@ -8,7 +8,7 @@ if command -v complete >/dev/null 2>&1; then
       versions=\$(\\ls -1 $RB_RUBIES_DIR | sed -e "s/^/@/")
       cmds=\$(\\ls -1 `which rb`/.. | grep rb-  | sed -e "s/^rb-//" | sed -e "s/*$//")
 
-      if [[ \$COMP_CWORD == 1 ]]; then
+      if [[ \$COMP_CWORD == 1 ]] || [[ \$COMP_CWORD == 2 ]] && [[ \${COMP_WORDS[1]} == 'exec' ]]; then
         COMPREPLY=( \$(compgen -W "\${cmds} \${versions} @system --version -f" -- \${cur}) )
         return 0
       fi


### PR DESCRIPTION
Does just that.  Designed to run a single command using a given ruby
version.  Useful in environments where you don't want auto handling
but want to ensure commands run with the correct ruby version.

Closes #18.

@jcredding ready for review.
