### PR TITLE
added a `--quiet` flag to the init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Open a terminal and run this command ([view source](http://git.io/rb--install)):
 $ curl -L http://git.io/rb--install | sh
 ```
 
-## Init
+### Init
 
 Add rb init to your shell startup script.  This installs tab completions and enables modifying the env vars.
 
@@ -44,10 +44,20 @@ Add rb init to your shell startup script.  This installs tab completions and ena
 eval "$(rb init)"
 ```
 
-(optional) If you want automatic handling, add the `--auto` flag.  In additon to the normal init above, `$PROMPT_COMMAND` is updated to activate any new ruby version as you change directories.  **Again, this is optional.**
+### Auto Mode
+
+(optional) If you want automatic handling, add the `--auto` flag to the init.  In additon to the normal init above, `$PROMPT_COMMAND` is updated to activate any new ruby version as you change directories.  **Again, this is optional.**
 
 ```bash
 eval "$(rb init --auto)"
+```
+
+### Quiet Mode
+
+By default, rb outputs a warning saying which version/source it activates. If you want to silence these warnings, add the `--quiet` flag to the init.
+
+```bash
+eval "$(rb init --quiet)"
 ```
 
 ## Usage

--- a/libexec/rb
+++ b/libexec/rb
@@ -74,8 +74,9 @@ _rb_activate () {
       # an installed version requested, activate it
       _rb_unset_env && set_state "$VERSION" "$SOURCE" && set_env && MSG="Activated $VERSION"
     fi
-    info "$MSG ($SOURCE)"
+    [[ ! "$RB_QUIET_MODE" == "true" ]] && info "$MSG ($SOURCE)"
   fi
+  return 0
 }
 
 _rb_auto_activate () { [[ "$PWD" != "$RB_PWD" ]] && export RB_PWD="$PWD" && _rb_activate; }

--- a/libexec/rb-help
+++ b/libexec/rb-help
@@ -12,7 +12,7 @@ usage: rb [@<version>]
        rb help CMD
        rb status
        rb list
-       rb init [--auto]
+       rb init [--auto] [--quiet]
        rb --version
 
 More Info:
@@ -64,10 +64,10 @@ USAGE
   elif [[ "$command" == "init" ]]; then
 
     cat <<USAGE
-Output a script to eval in the shell.
+Output an initialization script to eval in the shell.
 
 usage: eval "\$(rb init)"
-       eval "\$(rb init --auto)"
+       eval "\$(rb init [--auto] [--quiet])"
 USAGE
     exit 0
 

--- a/libexec/rb-init
+++ b/libexec/rb-init
@@ -18,13 +18,13 @@ if command -v complete >/dev/null 2>&1; then
         return 0
       fi
 
-      if [[ \$COMP_CWORD == 2 ]] && [[ \${COMP_WORDS[1]} == 'init' ]]; then
-        COMPREPLY=( \$(compgen -W "--auto" -- \${cur}) )
+      if [[ \$COMP_CWORD == 2 ]] && [[ \${COMP_WORDS[1]} == 'help' ]]; then
+        COMPREPLY=( \$(compgen -W "\${cmds}" -- \${cur}) )
         return 0
       fi
 
-      if [[ \$COMP_CWORD == 2 ]] && [[ \${COMP_WORDS[1]} == 'help' ]]; then
-        COMPREPLY=( \$(compgen -W "\${cmds}" -- \${cur}) )
+      if [[ \$COMP_CWORD > 1 ]] && [[ \${COMP_WORDS[1]} == 'init' ]]; then
+        COMPREPLY=( \$(compgen -W "--auto --quiet" -- \${cur}) )
         return 0
       fi
     fi
@@ -33,11 +33,23 @@ if command -v complete >/dev/null 2>&1; then
 fi
 BASH_TAB_COMPLETION
 
-if [ "$1" = "--auto" ]; then
+for arg in $@; do
+  shift
+  if [ "$arg" = "--quiet" ]; then
 
-  # (optional) auto mode (update ruby version as you change directories)
+    # (optional) silences warnings show when a new ruby version/source is activated
 
-  cat <<AUTO_MODE
+    cat <<QUIET_MODE
+export RB_QUIET_MODE=true
+QUIET_MODE
+
+  fi
+
+  if [ "$arg" = "--auto" ]; then
+
+    # (optional) auto mode (update ruby version as you change directories)
+
+    cat <<AUTO_MODE
 PROMPT_COMMAND="${PROMPT_COMMAND%% }"
 if [[ -n "$PROMPT_COMMAND" ]]; then
   if [[ ! "$PROMPT_COMMAND" == *_rb_auto_activate* ]]; then
@@ -49,7 +61,8 @@ else
 fi
 AUTO_MODE
 
-fi
+  fi
+done
 
 cat <<SOURCE_RB
 source `which rb`


### PR DESCRIPTION
Use this to silence warnings when the ruby version/source are changed.
This updates the init command and the help/usage info.

@jcredding ready for review.
