### PR TITLE
simpler `--auto` implementation

### DIFF
--- a/libexec/rb-init
+++ b/libexec/rb-init
@@ -50,15 +50,7 @@ QUIET_MODE
     # (optional) auto mode (update ruby version as you change directories)
 
     cat <<AUTO_MODE
-PROMPT_COMMAND="${PROMPT_COMMAND%% }"
-if [[ -n "$PROMPT_COMMAND" ]]; then
-  if [[ ! "$PROMPT_COMMAND" == *_rb_auto_activate* ]]; then
-    PROMPT_COMMAND="${PROMPT_COMMAND%%;}"
-    PROMPT_COMMAND="$PROMPT_COMMAND; _rb_auto_activate"
-  fi
-else
-  PROMPT_COMMAND="_rb_auto_activate"
-fi
+PROMPT_COMMAND="_rb_auto_activate; $PROMPT_COMMAND"
 AUTO_MODE
 
   fi


### PR DESCRIPTION
Don't bother with complicated handling of an existing PROMPT_COMMAND.
Just prepend `_rb_auto_activate;` to any existing PROMPT_COMMAND
value.

@jcredding ready for review.
