### PR TITLE
Use `dirname` for getting rb's install directory

### DIFF
--- a/libexec/rb
+++ b/libexec/rb
@@ -86,7 +86,7 @@ _rb_auto_activate () { [[ "$PWD" != "$RB_PWD" ]] && export RB_PWD="$PWD" && _rb_
 
 rb () {
   reset () { _rb_unset_env; _rb_activate $@; }
-  local cmd_arg="$1" cmd_bin="$(readlink `which rb`)/../rb-$1"
+  local cmd_arg="$1" cmd_bin="$(dirname $(readlink `which rb`))/rb-$1"
   if [ -x "$cmd_bin" ]; then
     shift 1; eval "$cmd_bin $@"
   else

--- a/libexec/rb-init
+++ b/libexec/rb-init
@@ -6,7 +6,7 @@ if command -v complete >/dev/null 2>&1; then
     if [ -d "$RB_RUBIES_DIR" ]; then
       cur="\${COMP_WORDS[COMP_CWORD]}"
       versions=\$(\\ls -1 $RB_RUBIES_DIR | sed -e "s/^/@/")
-      cmds=\$(\\ls -1 `which rb`/.. | grep rb-  | sed -e "s/^rb-//" | sed -e "s/*$//")
+      cmds=\$(\\ls -1 $(dirname $(readlink `which rb`)) | grep rb- | sed -e "s/^rb-//" | sed -e "s/*$//")
 
       if [[ \$COMP_CWORD == 1 ]]; then
         COMPREPLY=( \$(compgen -W "\${cmds} \${versions} @system --version -f" -- \${cur}) )


### PR DESCRIPTION
On Fedora systems, a command like the following:

``` bash
ls -la $(readlink `which rb`)/..
```

fails. It says `ls: cannot access <path>: Not a directory`. I
believe it is complaining about the fact that the `rb` bin is
not a directory. I can't find exactly what this is, but it seems
to be some strict path handling.

Anyway, this changes the couple of places I've found in `rb` that
use the pattern of calling readling and appending `..`. I switched
to using `dirname` instead which is works with Fedora and Mac OS
X.
