### PR TITLE
`rb each` command for running a command across all installed rubies

### DIFF
--- a/libexec/rb-each
+++ b/libexec/rb-each
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+for arg in $@; do
+  shift
+  if [[ "$arg" == "--" ]]; then
+    break
+  fi
+done
+
+if [[ $# -eq 0 ]]; then
+  echo "rb: each needs a command to run" >&2
+  exit 1
+fi
+
+CMD="$*"
+
+for v in `/bin/ls $RB_RUBIES_DIR`; do
+  shift
+
+  [[ ! "$RB_QUIET_MODE" == "true" ]] && echo -e "===[$v]===================================================================" >&2;
+  rb exec "@$v" -- "$CMD"
+done

--- a/libexec/rb-help
+++ b/libexec/rb-help
@@ -9,6 +9,7 @@ if [ -z $command ]; then
 usage: rb @[<version>]
        rb -f FILE
        rb exec [@<version>] [-f FILE] -- COMMAND
+       rb each -- COMMAND
        rb help [CMD]
        rb status
        rb list
@@ -30,6 +31,15 @@ Execute a command using a specific ruby version
 usage: rb exec -- COMMAND
        rb exec @<version> -- COMMAND
        rb exec -f FILE -- COMMAND
+USAGE
+    exit 0
+
+  elif [[ "$command" == "each" ]]; then
+
+    cat <<USAGE
+Execute (rb exec) a command across all installed ruby versions
+
+usage: rb each -- COMMAND
 USAGE
     exit 0
 


### PR DESCRIPTION
This command work much like `rb exec` except it runs the given cmd,
not against a _given_ rubie, but against _all installed_ rubies.

The particular use-case I have in mind for this cmd is for running
a build against multiple rubies.

Closes #38.

@jcredding ready for review.
