### PR TITLE
switch to finding default `.ruby-version` file in the rubies dir

### DIFF
--- a/libexec/rb
+++ b/libexec/rb
@@ -57,8 +57,8 @@ _rb_activate () {
     [[ ! $1 =~ ^\/ ]] && file="$PWD/$file"
     set_file_version "$file"
   fi
-  # from $RB_HOME_DIR/.ruby-version, if present
-  [ -z "$VERSION" ] && set_file_version "$RB_HOME_DIR/$RB_VERSION_FILE"
+  # from $RB_RUBIES_DIR/.ruby-version, if present
+  [ -z "$VERSION" ] && set_file_version "$RB_RUBIES_DIR/$RB_VERSION_FILE"
   # default to the system version
   [ -z "$VERSION" ] && VERSION="system" && SOURCE="default"
 


### PR DESCRIPTION
This switches to looking for the default ruby version settings file
in the rubies root dir instead of the rb root dir.

The problem with storing the default version in the rb root dir is
that when you upgrade rb, that dir is removed and recreated.  Therefore
your ruby version file is destroyed with it and you have to manually
recreate it.

This moves the file to live with the rubies in the rubies root dir.
This dir will not be destroyed when you upgrade rb so your default
ruby version will remain intact between upgrades.

@jcredding this has been annoying me for the last few upgrades.  finally doing something about it.  Ready for review.
