### PR TITLE
create `~/.rubies` rubie dir on install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,7 @@
 set -e
 
 RB_HOME_DIR="$HOME/.rb"
+RB_RUBIES_DIR="$HOME/.rubies"
 RB_RELEASE="1.0.3"
 
 # make sure the bin path is in place
@@ -23,6 +24,10 @@ RB_RELEASE="1.0.3"
 # install in the bin path
 
       ln -sf "$RB_HOME_DIR/libexec/rb" "$BIN_PATH"
+
+# make the rubies dir
+
+      mkdir -p "$RB_RUBIES_DIR"
 
 # done!
 


### PR DESCRIPTION
This is the dir where rb expects ruby versions to be installed, why
make the user manually create it?  Plus, I want to move the default
ruby version location into this dir so it is becoming more important
to rb.

**Note**: I chose to not rm this dir on uninstall b/c I don't want
to remove all the user's rubies in the process. :)

Related to #40.

@jcredding ready for review.
