### PR TITLE
updates inspired by working on Chpg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # rb
 
+Switch between installed Ruby versions.
+
 ```
 $ rb @1.9.3 && ruby -v                           # activate '1.9.3' install
 $ echo 'ree' > ./.ruby-version && rb && ruby -v  # activate current `.ruby-version` ('ree') install
 $ rb @system && ruby -v                          # activate system install
 $ rb help
 ```
-
-Switch between installed Ruby versions.
 
 ## What It Does...
 

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -e
 
 RB_HOME_DIR="$HOME/.rb"
 RB_RUBIES_DIR="$HOME/.rubies"
-RB_RELEASE="1.0.4"
+RB_RELEASE="1.0.5-test1"
 
 # make sure the bin path is in place
 

--- a/install.sh
+++ b/install.sh
@@ -14,10 +14,11 @@ RB_RELEASE="1.0.4"
 
 # download the release tag and link to the bin path
 
-      rm -rf "$RB_HOME_DIR" && mkdir -p "$RB_HOME_DIR"
+      mkdir -p "$RB_HOME_DIR"
       pushd "$RB_HOME_DIR" > /dev/null &&
-        curl -L "https://github.com/redding/rb/tarball/$RB_RELEASE" | tar xzf - */libexec/*
-        mv *rb-* "rb-$RB_RELEASE"
+        rm -rf "rb-$RB_RELEASE"
+        curl -L "https://github.com/redding/rb/tarball/$RB_RELEASE" | tar xzf - "*/libexec/*"
+        mv *-rb-* "rb-$RB_RELEASE"
         ln -sf "rb-$RB_RELEASE/libexec"
       popd > /dev/null
 

--- a/libexec/rb
+++ b/libexec/rb
@@ -75,7 +75,7 @@ _rb_activate () {
       return 1
     else
       # an installed version requested, activate it
-      _rb_unset_env && set_state "$VERSION" "$SOURCE" && set_env && MSG="Activated $VERSION"
+      _rb_unset_env && set_state "$VERSION" "$SOURCE" && set_env && MSG="Activated Ruby-$VERSION"
     fi
     [[ ! "$RB_QUIET_MODE" == "true" ]] && info "$MSG ($SOURCE)"
   fi

--- a/libexec/rb
+++ b/libexec/rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export RB_RELEASE="1.0.4"
+export RB_RELEASE="1.0.5-test1"
 
 [ -n "$RB_HOME_DIR"     ] || export RB_HOME_DIR="$HOME/.rb"
 [ -n "$RB_RUBIES_DIR"   ] || export RB_RUBIES_DIR="$HOME/.rubies"

--- a/libexec/rb-init
+++ b/libexec/rb-init
@@ -50,7 +50,7 @@ QUIET_MODE
     # (optional) auto mode (update ruby version as you change directories)
 
     cat <<AUTO_MODE
-PROMPT_COMMAND="_rb_auto_activate; $PROMPT_COMMAND"
+export PROMPT_COMMAND="_rb_auto_activate; $PROMPT_COMMAND"
 AUTO_MODE
 
   fi

--- a/release.sh
+++ b/release.sh
@@ -5,22 +5,21 @@ RB_RELEASE='1.0.4'
 # check uncommitted changes
 
       if ! git diff-index --quiet HEAD --; then
-        echo "There are files that need to be committed first." && return 1
-      fi
-
-# tag the release
-
-      if git tag -a -m "Release $RB_RELEASE" "$RB_RELEASE"; then
-        echo "Tagged $RB_RELEASE release."
-
-# push the changes and tags
-
-        git push
-        git push --tags
-
-        echo "Pushed git commits and tags"
+        echo "There are files that need to be committed first."
       else
-        echo "Release aborted."
+        # tag the release
+
+              if git tag -a -m "Release $RB_RELEASE" "$RB_RELEASE"; then
+                echo "Tagged $RB_RELEASE release."
+
+        # push the changes and tags
+
+                if git push && git push --tags; then
+                  echo "Pushed git commits and tags"
+                else
+                  echo "Release aborted."
+                fi
+              else
+                echo "Release aborted."
+              fi
       fi
-
-

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-RB_RELEASE='1.0.4'
+RB_RELEASE='1.0.5-test1'
 
 # check uncommitted changes
 


### PR DESCRIPTION
These are various updates I found from adapting Rb to Chpg. See https://github.com/redding/chpg/pull/1 for that work.

### qualify that Rb is activating a _Ruby_ version when activating

I noticed this while working on chpg. Chpg outputs a similar
status message and having both of these messages output together
it became apparent that using a qualifier on the message would be
helpful.

### properly export the PROMPT_COMMAND env variable in auto mode

This is needed to have the env variable changes persist across
other changes made to it by other systems. I noticed this while
testing Chpg and using it alongside Rb.

### make the install and release scripts more robust

This updates the install script to no longer wipe the `.rb` dir
but instead keep the history of previously installed versions.
This allows any custom files added to the `.rb` dir to persist
across new installs.

This updates the release script to actually halt on fault
conditions and makes the script more fault tolerant.

These came out of working on Chpg and needing the features there.

### tweak the REAME and add a new test1 release

This tweak is in response to a similar change in Chpg and is for
better readability. The test1 release is so I could test the
Chpg inspired changes locally.