### PR TITLE
Add shim support (v1.1.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# rb — notes for agents and non-interactive shells
+
+`rb` switches Ruby versions. For automated/non-interactive use, the key
+fact is **shims**: `$HOME/.rb/shims` is on `PATH` (via `eval "$(rb
+init)"`), and each shim resolves the nearest `.ruby-version` at run time.
+
+- Bare `ruby`/`bundle`/`rspec`/`rails`/etc. resolve the project's Ruby
+  with **no `rb @` prefix** — in scripts, cron, and agent shells.
+- Resolution is per-directory and lazy, so `cd proj && ruby -v` is
+  correct even within a single command.
+- New gem binary not found? Run `rb reshim` (auto-runs after
+  gem/bundle installs).
+- `rb which ruby` → the real resolved path. `rb resolve` → the version +
+  source for the current dir.
+- `rb @<version> -- <cmd>` / `rb exec` run a one-off command under a
+  specific version without changing the shell.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.1.0 / 2026-07-16
+
+* Shims: resolve the correct Ruby for bare commands (`ruby`, `bundle`,
+  `rspec`, …) in any shell, including non-interactive ones, with no
+  `rb @` prefix. New `rb reshim`, `rb which`, `rb resolve` commands;
+  `rb init` adds the shims dir to `PATH`; auto-reshim after gem/bundle
+  installs.
+* `rb exec` no longer spawns a login/interactive subshell.
+* docs: fix dead `git.io` install URLs and typos
+
 ## 1.0.7 / 2026-03-10
 
 * Ensure clean exit code when sourced; the source guard's false test no longer propagates exit code 1

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ $ rb help
 
 Each installed version of ruby should live in `$HOME/.rubies/`.  Install versions any way you prefer; [ruby-build](https://github.com/sstephenson/ruby-build) is recommended.
 
+## Shims
+
+`rb` installs lightweight **shims** (in `$HOME/.rb/shims`, added to your `PATH` by `rb init`) for every executable across your installed rubies. A shim resolves the correct version from the nearest `.ruby-version` at **run time**, so bare commands — `ruby`, `bundle`, `rspec`, `rails`, … — use the right version in any shell, including non-interactive ones (scripts, cron, AI agents) where prompt-based auto-activation never runs. No `rb @` prefix required.
+
+Regenerate shims with `rb reshim`. This runs automatically after `gem install`/`bundle install` (and similar), and on install. Run it manually after installing a new ruby. Use `rb which COMMAND` to see the real path a command resolves to, and `rb resolve` to see the version that applies in the current directory.
+
 ## Install
 
 Open a terminal and run this command ([view source](https://raw.githubusercontent.com/redding/rb/main/install.sh)):

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ Each installed version of ruby should live in `$HOME/.rubies/`.  Install version
 
 ## Install
 
-Open a terminal and run this command ([view source](http://git.io/rb--install)):
+Open a terminal and run this command ([view source](https://raw.githubusercontent.com/redding/rb/main/install.sh)):
 
 (change PREFIX as needed; it defaults to `/usr/local`)
 
 ```
-$ curl -L http://git.io/rb--install | PREFIX=/user/local sh
+$ curl -L https://raw.githubusercontent.com/redding/rb/main/install.sh | PREFIX=/usr/local sh
 ```
 
 ### Init
@@ -48,7 +48,7 @@ eval "$(rb init)"
 
 ### Auto Mode
 
-(optional) If you want automatic handling, add the `--auto` flag to the init.  In additon to the normal init above, `$PROMPT_COMMAND` is updated to activate any new ruby version as you change directories.  **Again, this is optional.**
+(optional) If you want automatic handling, add the `--auto` flag to the init.  In addition to the normal init above, `$PROMPT_COMMAND` is updated to activate any new ruby version as you change directories.  **Again, this is optional.**
 
 ```bash
 eval "$(rb init --auto)"
@@ -76,7 +76,7 @@ $ rb @system
 
 ### `.ruby-version` Files
 
-If no explicit @<verion> parameter is specified, rb will look for the version in a file named `.ruby-version` in your current directory, its parent directories, or your home directory.  The `.ruby-version` files are expected to contain nothing but the version requested.
+If no explicit @<version> parameter is specified, rb will look for the version in a file named `.ruby-version` in your current directory, its parent directories, or your home directory.  The `.ruby-version` files are expected to contain nothing but the version requested.
 
 ```
 $ echo "1.9.3-p0" > $HOME/.ruby-version
@@ -106,10 +106,10 @@ source `which rb` && rb @
 
 ## Uninstall
 
-Open a terminal and run this command ([view source](http://git.io/rb--uninstall)):
+Open a terminal and run this command ([view source](https://raw.githubusercontent.com/redding/rb/main/uninstall.sh)):
 
 ```
-$ curl -L http://git.io/rb--uninstall | sh
+$ curl -L https://raw.githubusercontent.com/redding/rb/main/uninstall.sh | sh
 ```
 
 ## Contributing

--- a/install.sh
+++ b/install.sh
@@ -30,6 +30,10 @@ RB_RELEASE="1.0.7"
 
       mkdir -p "$RB_RUBIES_DIR"
 
+# generate shims for any installed rubies (safe if none yet)
+
+      "$RB_HOME_DIR/libexec/rb-reshim" || true
+
 # done!
 
       echo "Installed at ${BIN_PATH}/rb"

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -e
 
 RB_HOME_DIR="$HOME/.rb"
 RB_RUBIES_DIR="$HOME/.rubies"
-RB_RELEASE="1.0.7"
+RB_RELEASE="1.1.0"
 
 # make sure the bin path is in place
 

--- a/libexec/_rb-resolve
+++ b/libexec/_rb-resolve
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# Shared resolver for rb shims and `rb exec`. Sourced, never executed
+# directly. Self-sufficient: does not require `libexec/rb` to be sourced.
+
+: "${RB_HOME_DIR:=$HOME/.rb}"
+: "${RB_RUBIES_DIR:=$HOME/.rubies}"
+: "${RB_VERSION_FILE:=.ruby-version}"
+
+# Resolve the version + source for the current $PWD (and optional CLI arg
+# mirroring `_rb_activate`: `@<version>` or a version FILE path). Sets
+# globals RB_RESOLVED_VERSION and RB_RESOLVED_SOURCE.
+_rb_resolve_version () {
+  local arg="$1" version="" source="" path
+
+  # search pwd + parents for a .ruby-version file
+  path="$PWD"
+  while [ -n "$path" ]; do
+    if [ -f "$path/$RB_VERSION_FILE" ]; then
+      read -r version < "$path/$RB_VERSION_FILE"
+      version="${version//[[:space:]]/}"
+      source="from $path/$RB_VERSION_FILE"
+      break
+    fi
+    [ "$path" = "/" ] && break
+    path="${path%/*}"; [ -z "$path" ] && path="/"
+  done
+
+  # CLI override: @<version> or a version FILE
+  if [[ "$arg" == @* ]]; then
+    version="${arg:1}"; source="from command line"
+  elif [ -n "$arg" ] && [ -f "$arg" ]; then
+    read -r version < "$arg"
+    version="${version//[[:space:]]/}"; source="from $arg"
+  fi
+
+  # default file, then "system"
+  if [ -z "$version" ] && [ -f "$RB_RUBIES_DIR/$RB_VERSION_FILE" ]; then
+    read -r version < "$RB_RUBIES_DIR/$RB_VERSION_FILE"
+    version="${version//[[:space:]]/}"
+    source="from $RB_RUBIES_DIR/$RB_VERSION_FILE"
+  fi
+  [ -z "$version" ] && { version="system"; source="default"; }
+
+  RB_RESOLVED_VERSION="$version"
+  RB_RESOLVED_SOURCE="$source"
+}
+
+# Echo the on-disk root for a version (resolving a symlinked dir).
+_rb_resolved_root () {
+  local v="$1" dv="$RB_RUBIES_DIR/$1"
+  [ -h "$dv" ] && v="$(readlink -n "$dv" | sed 's:/$::')"
+  printf '%s' "$RB_RUBIES_DIR/$v"
+}
+
+# Export the full env for a resolved (non-system) version and prepend its
+# bin dirs to PATH. Mirrors `set_env` in libexec/rb exactly.
+_rb_apply_env () {
+  local v="$RB_RESOLVED_VERSION" dv="$RB_RUBIES_DIR/$RB_RESOLVED_VERSION"
+  [ -h "$dv" ] && v="$(readlink -n "$dv" | sed 's:/$::')"
+  export RUBY_VERSION="$v" RUBY_ROOT="$RB_RUBIES_DIR/$v"
+  export GEM_HOME="$RUBY_ROOT/lib/ruby/gems" GEM_PATH="$RUBY_ROOT/lib/ruby/gems"
+  export PATH="$RUBY_ROOT/bin:$RUBY_ROOT/lib/ruby/gems/bin:$PATH"
+}
+
+# Echo $PATH with the rb shims dir removed (used for fallback search so a
+# shim never recurses into itself).
+_rb_path_without_shims () {
+  printf '%s' "$PATH" \
+    | awk -v RS=: -v ORS=: -v d="$RB_HOME_DIR/shims" '$0 != d' \
+    | sed 's/:$//'
+}
+
+# Print the rbenv-style "exists in these versions" hint to stderr.
+_rb_not_found_hint () {
+  local program="$1" vdir v found=()
+  for vdir in "$RB_RUBIES_DIR"/*/; do
+    [ -d "$vdir" ] || continue
+    v="$(basename "$vdir")"
+    if [ -x "$vdir/bin/$program" ] || [ -x "$vdir/lib/ruby/gems/bin/$program" ]; then
+      found+=("$v")
+    fi
+  done
+  if [ "${#found[@]}" -gt 0 ]; then
+    echo "" >&2
+    echo "The \`$program' command exists in these Ruby versions:" >&2
+    printf '  %s\n' "${found[@]}" >&2
+  fi
+}

--- a/libexec/rb
+++ b/libexec/rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export RB_RELEASE="1.0.7"
+export RB_RELEASE="1.1.0"
 
 [ -n "$RB_HOME_DIR"     ] || export RB_HOME_DIR="$HOME/.rb"
 [ -n "$RB_RUBIES_DIR"   ] || export RB_RUBIES_DIR="$HOME/.rubies"

--- a/libexec/rb-exec
+++ b/libexec/rb-exec
@@ -1,19 +1,30 @@
 #!/usr/bin/env bash
+set -e
+source "$(dirname "${BASH_SOURCE[0]}")/_rb-resolve"
 
+# argv before `--` selects the version (@<version> or -f FILE); the rest
+# is the command to run.
 argv=()
-
-for arg in $@; do
-  shift
-  if [[ "$arg" == "--" ]]; then
-    break
-  else
-    argv+=($arg)
-  fi
+while [ $# -gt 0 ]; do
+  a="$1"; shift
+  [ "$a" = "--" ] && break
+  argv+=("$a")
 done
 
-if [[ $# -eq 0 ]]; then
+if [ $# -eq 0 ]; then
   echo "rb: exec needs a command to run" >&2
   exit 1
 fi
 
-exec $SHELL -l -i -c "_rb_activate $argv && $*"
+# mirror `_rb_activate` arg handling: `-f FILE` passes FILE; `@ver` passes
+# the version string; otherwise resolve from cwd.
+sel=""
+case "${argv[0]:-}" in
+  -f) sel="${argv[1]:-}" ;;
+  *)  sel="${argv[0]:-}" ;;
+esac
+
+_rb_resolve_version "$sel"
+[ "$RB_RESOLVED_VERSION" != "system" ] && _rb_apply_env
+
+exec "$SHELL" -c "$*"

--- a/libexec/rb-help
+++ b/libexec/rb-help
@@ -10,6 +10,9 @@ usage: rb @[<version>]
        rb -f FILE
        rb exec [@<version>] [-f FILE] -- COMMAND
        rb each -- COMMAND
+       rb reshim
+       rb which COMMAND
+       rb resolve
        rb help [CMD]
        rb status
        rb list
@@ -40,6 +43,33 @@ USAGE
 Execute (rb exec) a command across all installed ruby versions
 
 usage: rb each -- COMMAND
+USAGE
+    exit 0
+
+  elif [[ "$command" == "reshim" ]]; then
+
+    cat <<USAGE
+Regenerate shims for all installed ruby versions (bin + gem bin).
+
+usage: rb reshim
+USAGE
+    exit 0
+
+  elif [[ "$command" == "which" ]]; then
+
+    cat <<USAGE
+Print the real path the given command resolves to in the current dir.
+
+usage: rb which COMMAND
+USAGE
+    exit 0
+
+  elif [[ "$command" == "resolve" ]]; then
+
+    cat <<USAGE
+Print the ruby version + source that applies in the current dir.
+
+usage: rb resolve
 USAGE
     exit 0
 

--- a/libexec/rb-init
+++ b/libexec/rb-init
@@ -56,6 +56,10 @@ AUTO_MODE
   fi
 done
 
+cat <<SHIMS_PATH
+export PATH="$RB_HOME_DIR/shims:\$PATH"
+SHIMS_PATH
+
 cat <<SOURCE_RB
 source `which rb`
 SOURCE_RB

--- a/libexec/rb-reshim
+++ b/libexec/rb-reshim
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -e
+
+: "${RB_HOME_DIR:=$HOME/.rb}"
+: "${RB_RUBIES_DIR:=$HOME/.rubies}"
+
+shims="$RB_HOME_DIR/shims"
+shim_exec="$RB_HOME_DIR/libexec/rb-shim-exec"
+mkdir -p "$shims"
+
+# union of executable basenames across all installed rubies
+names="$(
+  for vdir in "$RB_RUBIES_DIR"/*/; do
+    for bindir in "$vdir/bin" "$vdir/lib/ruby/gems/bin"; do
+      [ -d "$bindir" ] || continue
+      for f in "$bindir"/*; do
+        [ -f "$f" ] && [ -x "$f" ] && basename "$f"
+      done
+    done
+  done | sort -u
+)"
+
+# write/refresh a dispatch shim per name
+for name in $names; do
+  cat > "$shims/$name" <<SHIM
+#!/usr/bin/env bash
+set -e
+exec "$shim_exec" "$name" "\$@"
+SHIM
+  chmod +x "$shims/$name"
+done
+
+# prune stale shims no longer backed by any version
+for shim in "$shims"/*; do
+  [ -e "$shim" ] || continue
+  name="$(basename "$shim")"
+  printf '%s\n' $names | grep -qx "$name" || rm -f "$shim"
+done
+
+echo "rb: reshimmed $(printf '%s\n' $names | grep -c .) commands into $shims"

--- a/libexec/rb-resolve
+++ b/libexec/rb-resolve
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+source "$(dirname "${BASH_SOURCE[0]}")/_rb-resolve"
+_rb_resolve_version
+echo "$RB_RESOLVED_VERSION ($RB_RESOLVED_SOURCE)"

--- a/libexec/rb-shim-exec
+++ b/libexec/rb-shim-exec
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -e
+[ -n "$RB_DEBUG" ] && set -x
+
+source "$(dirname "${BASH_SOURCE[0]}")/_rb-resolve"
+
+program="${1:?rb-shim-exec: a program name is required}"; shift
+
+# resolve from cwd (shims pass no @version/-f)
+_rb_resolve_version
+
+target=""
+if [ "$RB_RESOLVED_VERSION" != "system" ] \
+    && [ -d "$(_rb_resolved_root "$RB_RESOLVED_VERSION")" ]; then
+  _rb_apply_env
+  for cand in "$RUBY_ROOT/bin/$program" "$RUBY_ROOT/lib/ruby/gems/bin/$program"; do
+    [ -x "$cand" ] && { target="$cand"; break; }
+  done
+fi
+
+# fallback: search PATH minus the shims dir (Homebrew, /usr/bin, ...)
+if [ -z "$target" ]; then
+  target="$(PATH="$(_rb_path_without_shims)" command -v "$program" 2>/dev/null || true)"
+fi
+
+if [ -z "$target" ]; then
+  echo "rb: $program: command not found" >&2
+  _rb_not_found_hint "$program"
+  exit 127
+fi
+
+# auto-reshim after gem/bundle install-type commands (can't exec -- reshim
+# must run after the install completes)
+reshim_after=""
+case "$program" in
+  gem)    case "$1" in install|update|uninstall|pristine|cleanup) reshim_after=1 ;; esac ;;
+  bundle) case "$1" in install|update|add|remove)                 reshim_after=1 ;; esac ;;
+esac
+
+if [ -n "$reshim_after" ]; then
+  "$target" "$@"; status=$?
+  "$RB_HOME_DIR/libexec/rb-reshim" >/dev/null 2>&1 || true
+  exit "$status"
+fi
+
+exec "$target" "$@"

--- a/libexec/rb-which
+++ b/libexec/rb-which
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+source "$(dirname "${BASH_SOURCE[0]}")/_rb-resolve"
+
+program="${1:?usage: rb which COMMAND}"
+_rb_resolve_version
+
+if [ "$RB_RESOLVED_VERSION" != "system" ]; then
+  root="$(_rb_resolved_root "$RB_RESOLVED_VERSION")"
+  for cand in "$root/bin/$program" "$root/lib/ruby/gems/bin/$program"; do
+    [ -x "$cand" ] && { echo "$cand"; exit 0; }
+  done
+fi
+
+target="$(PATH="$(_rb_path_without_shims)" command -v "$program" 2>/dev/null || true)"
+[ -n "$target" ] && { echo "$target"; exit 0; }
+
+echo "rb: $program: command not found" >&2
+_rb_not_found_hint "$program"
+exit 127

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-RB_RELEASE='1.0.7'
+RB_RELEASE='1.1.0'
 
 # check uncommitted changes
 


### PR DESCRIPTION
## Linear Ticket

No specific Linear ticket — this is the personal `redding/rb` version-manager repo, not Kajabi/Linear work.

## Description

rb activates a Ruby version only by mutating the current shell's PATH and gem environment, driven by a prompt hook or an explicit `rb` invocation. Shells that never draw a prompt — scripts, cron, and AI-agent command runners — get no activation, and tooling that reseeds each shell from a captured environment overwrites any activation a startup file performed. Bare Ruby commands could therefore not be relied on to pick the right version outside an interactive session.

## Solution

Add lightweight shims that resolve the version lazily at exec time from the nearest `.ruby-version`, so a static shims directory on PATH is enough and there is nothing for a reseeded environment to clobber. A shared resolver underpins the shims and applies the same RUBY_ROOT, RUBY_VERSION, GEM_HOME, and GEM_PATH activation does so gem lookup stays correct; it falls back to a search of PATH with the shims directory removed, and reports which versions provide a command when it is missing. Shims auto-regenerate after gem and bundle installs, `rb init` adds the shims directory to PATH, `install.sh` generates shims on install, and `reshim`/`which`/`resolve` commands are added. `rb exec` no longer spawns a login/interactive subshell. Also fixes the dead git.io install URLs.

## Customer Impact

No customer-facing impact — developer tooling. For rb users, bare Ruby commands (`ruby`, `bundle`, `rspec`, `rails`, …) now resolve the correct version per directory in any shell with no `rb @` prefix; existing `rb @`, auto mode, and all prior commands are unchanged.

## QA Testing Guidelines

Install from this branch (mirrors `install.sh` with the branch ref):

```
cd ~/.rb && curl -sL https://github.com/redding/rb/tarball/kr/shims | tar xzf - '*/libexec/*' && mv *-rb-* rb-1.1.0 && ln -sfn rb-1.1.0/libexec libexec && ~/.rb/libexec/rb-reshim
```

Then in a new shell:

- `rb --version` → `1.1.0`
- From a dir pinning a version (e.g. `.ruby-version` = 3.3.9): `ruby -v` / `bundle -v` / `rspec --version` resolve with no `rb @` prefix; `rb which ruby` → that version's bin; `rb resolve` → `3.3.9 (from …/.ruby-version)`
- Switch dirs (a repo pinning a different version) → `ruby -v` follows per directory
- `rb exec @<version> -- <cmd>` runs under a specific version; shell pipelines and exit codes are preserved
- `rb reshim` regenerates shims (auto-runs after gem/bundle installs; run manually after installing a new ruby)

To revert the local install: `ln -sfn ~/.rb/rb-1.0.7/libexec ~/.rb/libexec && rm -rf ~/.rb/shims`